### PR TITLE
Overlay does not trigger opaque mouseover

### DIFF
--- a/Afloat.m
+++ b/Afloat.m
@@ -365,6 +365,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 - (void) mouseEntered:(NSEvent*) e {
 	L0Log(@"%@", e);
 	
+	if ([self isWindowOverlay:[e window]]) return;
+	
 	[self animateFadeInForWindow:[e window]];
 
     BOOL focusFollowsMouse = [[AfloatStorage globalValueForKey:@"FocusFollowsMouse"] boolValue];
@@ -392,6 +394,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 - (void) mouseExited:(NSEvent*) e {
 	L0Log(@"%@", e);
+	
+	if ([self isWindowOverlay:[e window]]) return;
 	
 	[self animateFadeOutForWindow:[e window]];
 }


### PR DESCRIPTION
Before, if you set a window to 'overlay' clicks fall through. However, hovering over the window will still make it opaque (if it's transparent). When the 'opaque while active' active is enabled, this hovering behavior is no longer needed, since interactions clicks will not register with the window anyway.

This modification disables the 'opaque on hover' behavior for overlays, so that you can see what you're clicking on in the window underneath.
